### PR TITLE
create system block and setrw on it

### DIFF
--- a/app/src/main/java/com/topjohnwu/magisk/core/tasks/MagiskInstaller.kt
+++ b/app/src/main/java/com/topjohnwu/magisk/core/tasks/MagiskInstaller.kt
@@ -173,7 +173,9 @@ abstract class MagiskInstallImpl protected constructor(
 
         // adapted /scripts/flash_script.sh addon.d
         return arrayOf(
-            "blockdev --setrw $(grep -E \"/dev/block.* $systemPartition \" /proc/mounts | cut -f 1 -d ' ' )",
+            "rm -rf /dev/block/system_block",
+            "mkblknode /dev/block/system_block $systemPartition",
+            "blockdev --setrw /dev/block/system_block",
             "mount -o rw,remount $systemPartition",
             "rm -rf $addond/99-magisk.sh 2>/dev/null",
             "rm -rf $addond/magisk 2>/dev/null",

--- a/app/src/main/res/raw/manager.sh
+++ b/app/src/main/res/raw/manager.sh
@@ -214,6 +214,11 @@ run_migrations() { return; }
 
 grep_prop() { return; }
 
+mkblknode(){
+    local blk_mm="$(mountpoint -d "$2" | sed "s/:/ /g")"
+    mknod "$1" -m 666 b $blk_mm
+}
+
 #############
 # Initialize
 #############


### PR DESCRIPTION
```
$ grep " / " /proc/mounts
/dev/root
$ blockdev --setrw $(grep -E "/dev/block.* / " /proc/mounts | cut -f 1 -d ' ' )
(nothing)
$
```
and cause:

```
- Adding addon.d survival script
! Installation failed
```