### PR TITLE
Fix manifest output

### DIFF
--- a/releasehelper.sh
+++ b/releasehelper.sh
@@ -40,7 +40,7 @@ case "$BRANCH" in
         ;;
 esac
 
-echo <<EOF > "$BRANCH.json"
+cat <<EOF > "$BRANCH.json"
 {
   "magisk": {
     "version": "${VERSION}",


### PR DESCRIPTION
This PR fixes the version manifests, currently they are blank as the `<<EOF` syntax is only valid with the `cat` command.